### PR TITLE
fix: Use correct keys when parsing action URL and custom Attributes from notification response

### DIFF
--- a/sdk/src/main/java/com/magicbell/sdk/feature/notification/Notification.kt
+++ b/sdk/src/main/java/com/magicbell/sdk/feature/notification/Notification.kt
@@ -18,11 +18,13 @@ data class Notification(
   val id: String,
   val title: String,
   val content: String? = null,
-  @SerialName("action_url")
+  @SerialName("actionUrl")
+  @JsonNames("action_url")
   val actionURL: String? = null,
   val category: String? = null,
   val topic: String? = null,
-  @SerialName("custom_attributes")
+  @SerialName("customAttributes")
+  @JsonNames("custom_attributes")
   val customAttributes: JsonObject? = null,
   val recipient: Recipient? = null,
   @Serializable(with = DateSerializer::class)


### PR DESCRIPTION
The Android SDK was using outdated keys for both, `actionUrl` and `customAttributes`.

I've created a broadcast via the CLI that contains both, action-url and custom attributes:
```
magicbell broadcasts create --action-url "act://ion" --content "Via CLI" --title "Check this Broadcast" --custom-attributes '{custom:"Value"}' --recipients "hi@ullrich.is"
```
 
Here's the API response that clearly shows the names of the keys. I've updated the parser accordingly.
![CleanShot 2024-04-25 at 10 48 48@2x](https://github.com/magicbell-io/magicbell-android/assets/13815/3f2073f9-a0e2-45fc-b708-4cd766e12495)

# Test Plan

I was able to confirm in the debugger that the correct values arrive now.

![CleanShot 2024-04-25 at 10 47 09@2x](https://github.com/magicbell-io/magicbell-android/assets/13815/1cce9270-916e-4b6a-a6f9-c0531018cb09)
