### PR TITLE
chore: Bump SDK version to 2.0.0

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -50,10 +50,10 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
 
   // MagicBell
-  // implementation 'com.magicbell:magicbell-sdk:1.0.0'
+  // implementation 'com.magicbell:magicbell-sdk:2.0.0'
   implementation project(":sdk") // using local dependency
 
-  // implementation 'com.magicbell:magicbell-sdk-compose:1.0.0'
+  // implementation 'com.magicbell:magicbell-sdk-compose:2.0.0'
   implementation project(":sdk-compose") // using local dependency
 
   // Compose

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-version = '1.0.0'
+version = '2.0.0'
 group = 'com.magicbell'
 
 def isReleaseBuild() {


### PR DESCRIPTION
This PR prepares the SDK to be released as version 2.0.0 to Maven Central.

Currently we have versions 1.0.0 released there, which can be found via https://central.sonatype.com/search?q=magicbell


We still need to regain access to the `com.magicbell` namespace on Maven Central. I'm going to try and use `josue@magicbell.io` and reset the password. This is not part of this PR though, and will be coordinated via Slack.