### PR TITLE
Migrating to modern maven publish plugin

### DIFF
--- a/.github/workflows/release-gradle-publish.yml
+++ b/.github/workflows/release-gradle-publish.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [ created ]
 
+env:
+  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+  ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEYID }}
+  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_USERNAME }}
+  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PASSWORD }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -22,16 +29,6 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
   
-    - name: Setup Keyring
-      id: keyring
-      env:
-        KEYRING_FILE: ${{ runner.temp }}/publish-keyring.gpg
-        DATA: ${{ secrets.SIGNING_KEYRING }}
-      run: |
-        echo "Creating Keyring file at $KEYRING_FILE"
-        echo $DATA | base64 -di > $KEYRING_FILE
-        echo "keyringFile=$KEYRING_FILE" >> "$GITHUB_OUTPUT"
-
     - name: Sanity Check
       run: |
         ./gradlew \
@@ -41,17 +38,11 @@ jobs:
     - name: Publish to Maven Local
       run: |
         ./gradlew \
-          -Psigning.keyId="${{ secrets.SIGNING_KEYID }}" \
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="${{ steps.keyring.outputs.keyringFile }}" \
           sdk:publishToMavenLocal sdk-compose:publishToMavenLocal
 
     - name: Publish to Maven
       run: |
         ./gradlew \
-          -Psigning.keyId="${{ secrets.SIGNING_KEYID }}" \
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="${{ steps.keyring.outputs.keyringFile }}" \
           -PNEXUS_USERNAME="${{ secrets.NEXUS_USERNAME }}" \
           -PNEXUS_PASSWORD="${{ secrets.NEXUS_PASSWORD }}" \
           sdk:publish sdk-compose:publish

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -1,103 +1,36 @@
-apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-version = '3.0.0'
-group = 'com.magicbell'
+mavenPublishing {
+  coordinates("com.magicbell", null, "3.0.0")
 
-def isReleaseBuild() {
-  return version.contains("SNAPSHOT") == false
-}
+  // Configure code signing constants according to
+  // https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
+  signAllPublications()
 
-def getReleaseRepositoryUrl() {
-  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-      : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
+  pom {
+    name = "MagicBell"
+    description = 'Official MagicBell SDK for Android. The notification inbox for your product.'
+    url = 'https://www.magicbell.com/'
 
-def getSnapshotRepositoryUrl() {
-  return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-      : "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-}
-
-def getRepositoryUsername() {
-  return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-  return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
-}
-
-def getGpgKey() {
-  return hasProperty('SIGNING_KEY') ? SIGNING_KEY : ""
-}
-
-def getGpgPassphrase() {
-  return hasProperty('PASSPHRASE') ? PASSPHRASE : ""
-}
-
-def configurePom(pom) {
-  pom.name = 'MagicBell'
-  pom.description = 'Official MagicBell SDK for Android. The notification inbox for your product.'
-  pom.url = 'https://www.magicbell.com/'
-
-  pom.scm {
-    url = 'https://github.com/magicbell/magicbell-android.git'
-    connection = 'scm:git@github.com:magicbell/magicbell-android.git'
-    developerConnection = 'scm:git@github.com:magicbell/magicbell-android.git'
-  }
-
-  pom.licenses {
-    license {
-      name = 'Custom'
-      url = 'https://github.com/magicbell/magicbell-android/blob/main/LICENSE'
-      distribution = 'repo'
+    scm {
+      url = 'https://github.com/magicbell/magicbell-android.git'
+      connection = 'scm:git@github.com:magicbell/magicbell-android.git'
+      developerConnection = 'scm:git@github.com:magicbell/magicbell-android.git'
     }
-  }
 
-  pom.developers {
-    developer {
-      id = 'magicbell'
-      name = 'MagicBell'
-    }
-  }
-}
-
-afterEvaluate { project ->
-  publishing {
-
-    repositories {
-      maven {
-        def releasesRepoUrl = getReleaseRepositoryUrl()
-        def snapshotsRepoUrl = getSnapshotRepositoryUrl()
-        url = isReleaseBuild() ? releasesRepoUrl : snapshotsRepoUrl
-
-        credentials(PasswordCredentials) {
-          username = getRepositoryUsername()
-          password = getRepositoryPassword()
-        }
+    licenses {
+      license {
+        name = 'Custom'
+        url = 'https://github.com/magicbell/magicbell-android/blob/main/LICENSE'
+        distribution = 'repo'
       }
     }
-  }
 
-  task javadocJar(type: Jar) {
-    archiveClassifier.set("javadoc")
-  }
-
-  publishing.publications.all { publication ->
-    publication.groupId = group
-    publication.version = version
-
-    artifact(javadocJar) // TODO include real documentation
-
-    configurePom(publication.pom)
-  }
-
-  signing {
-    required { isReleaseBuild() }
-    def gpgKey = getGpgKey()
-    def gpgPassphrase = getGpgPassphrase()
-    if (!gpgKey.isEmpty() && !gpgPassphrase.isEmpty()) {
-      useInMemoryPgpKeys(gpgKey, gpgPassphrase)
+    developers {
+      developer {
+        id = 'magicbell'
+        name = 'MagicBell'
+      }
     }
-    sign(publishing.publications)
   }
 }

--- a/scripts/update-version.ts
+++ b/scripts/update-version.ts
@@ -23,8 +23,8 @@ const replacements = [
   },
   {
     files: 'gradle-mvn-push.gradle',
-    from: /version = '\d\.\d\.\d'/g,
-    to: `version = '${version}'`,
+    from: /coordinates\("com.magicbell", null, "\d\.\d\.\d"\)/g,
+    to: `coordinates("com.magicbell", null, "${version}")`,
   }
 ]
 

--- a/sdk-compose/build.gradle
+++ b/sdk-compose/build.gradle
@@ -1,9 +1,10 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
+  id 'com.vanniktech.maven.publish' version '0.29.0'
 }
-
-apply from: '../gradle-mvn-push.gradle'
 
 android {
   compileSdk 31
@@ -46,16 +47,10 @@ dependencies {
   implementation project(':sdk')
 }
 
+apply from: '../gradle-mvn-push.gradle'
 afterEvaluate { project ->
-  publishing {
-    publications {
-      // Creates a Maven publication called "release".
-      release(MavenPublication) {
-        // Applies the component for the release build variant.
-        from components.release
-
-        artifactId = 'magicbell-sdk-compose'
-      }
-    }
+  mavenPublishing {
+    coordinates(null, "magicbell-sdk-compose", null)
+    publishToMavenCentral(SonatypeHost.S01)
   }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,11 +1,12 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
   id 'kotlinx-serialization'
   id 'de.mannodermaus.android-junit5'
+  id 'com.vanniktech.maven.publish' version '0.29.0'
 }
-
-apply from: '../gradle-mvn-push.gradle'
 
 android {
   compileSdk 31
@@ -60,16 +61,10 @@ dependencies {
   testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
 }
 
+apply from: '../gradle-mvn-push.gradle'
 afterEvaluate { project ->
-  publishing {
-    publications {
-      // Creates a Maven publication called "release".
-      release(MavenPublication) {
-        // Applies the component for the release build variant.
-        from components.release
-
-        artifactId = 'magicbell-sdk'
-      }
-    }
+  mavenPublishing {
+    coordinates(null, "magicbell-sdk", null)
+    publishToMavenCentral(SonatypeHost.S01)
   }
 }


### PR DESCRIPTION
## Change description

We've been using a pretty old way of publishing to maven central and I'd like to migrate to a newer plugin:
https://github.com/vanniktech/gradle-maven-publish-plugin

The also mention that they are the spiritual successor to the approach we're currnetly using (aka [Chris Banes initial implementation](https://github.com/chrisbanes/gradle-mvn-push))

Benefits:
- Simpler setup. Less code to maintain
- Support for new Central Portal. This will make it easier to migrate our distrubution from the now legacy OSSHR system we're using right now. ([migration docs](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/))
- Full support for passing secrets via env vars

## Test Plan

Tested locally, and build build signs and pulishes locally as expected:

```shell
$ ORG_GRADLE_PROJECT_signingInMemoryKey="...." \
  ORG_GRADLE_PROJECT_signingInMemoryKeyId="...." \
  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="..." \
  ./gradlew sdk:publishToMavenLocal
```

I compared the `pom-default.xml` files generated with the previous version and saw no difference.

## Type of Change

- [ ] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [ ] Enhancement  <!-- improves something existing -->

## Guidelines

- [ ] A [changeset] is included, or the change is not noteworthy enough to warrant one

<!-- links -->
[changeset]: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#i-am-in-a-single-package-repository